### PR TITLE
Fix warning (description_file)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,4 @@ extend-ignore = E203, E402, E501, E722, E741, F401, F407, W605
 profile = black
 
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Fixed the following warning: **UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead**